### PR TITLE
feat: add fast snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="3.0.0"></a>
+
+## 3.0.0 (2020-09-25)
+
+- Update README for new snippets
+- Add snippets for FASTElement:
+  - `fast-component` - Basic FASTElement Component
+  - `fast-cb` - `connectedCallback()` from FASTElement
+  - `fast-dcb` - `disconnectedCallback()` from FASTElement
+  - `fast-attr` - `@attr` decorator
+  - `fast-observable` - `@observable` decorator
+  - `fast-observable-notify` - `Observable.notify(...)`
+  - `fast-observable-track -` `Observable.track(...)`
+  - `fast-dispatch` - `$emit` to dispatch the custom event
+  - `fast-when` - `when`for conditional rendering
+- Add snippets for WebComponents/Generic:
+  - `wc-slot` - Define `<slot>`
+  - `wc-slot-named` - Define `<slot name="name">`
+
 <a name="2.0.0"></a>
 
 ## 2.0.0 (2020-08-07)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
   <img width="100" src="https://raw.githubusercontent.com/hardikpthv/vscode-lit-snippets/master/images/logo.png">
 </p>
 
-# Lit and Web Components Snippets for VS Code
+# Web Components Snippets for VS Code
 
 [![made-for-VSCode](https://img.shields.io/badge/Made%20for-VSCode-1f425f.svg)](https://code.visualstudio.com/)
+[![Version](https://vsmarketplacebadge.apphb.com/version/hardikpthv.lit-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.lit-snippets)
+[![Install](https://vsmarketplacebadge.apphb.com/installs/hardikpthv.lit-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.lit-snippets)
+[![Downloads](https://vsmarketplacebadge.apphb.com/downloads-short/hardikpthv.lit-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.lit-snippets)
+[![Ratings](https://vsmarketplacebadge.apphb.com/rating-short/hardikpthv.lit-snippets.svg)](https://marketplace.visualstudio.com/items?itemName=hardikpthv.lit-snippets)
 
-This extension for Visual Studio Code adds snippets of HTML and Javascript for [LitElement](https://lit-element.polymer-project.org), [lit-html](https://lit-html.polymer-project.org), [Stencil](https://stenciljs.com/) and [Web components](https://www.webcomponents.org/introduction).
+This extension for Visual Studio Code adds snippets of HTML and Javascript for [LitElement](https://lit-element.polymer-project.org), [lit-html](https://lit-html.polymer-project.org), [Stencil](https://stenciljs.com/), [FASTElement](https://www.fast.design/docs/fast-element/getting-started◊) and [Web components](https://www.webcomponents.org/introduction).
 
 Have a look at [CHANGELOG](CHANGELOG.md) for the latest changes
 
@@ -67,6 +71,20 @@ Start typing `lit-*` and hit `enter`, the snippet spreads out or e.g. `lit-compo
 | `stencil-cb`                    | `connectedCallback()` from Stencil                            |
 | `stencil-dcb`                   | `disconnectedCallback()` from Stencil                         |
 
+### FASTElement Snippets
+
+| Snippet                  | Purpose                                   |
+| ------------------------ | ----------------------------------------- |
+| `fast-component`         | Basic FASTElement Component               |
+| `fast-cb`                | `connectedCallback()` from FASTElement    |
+| `fast-dcb`               | `disconnectedCallback()` from FASTElement |
+| `fast-attr`              | `@attr` decorator                         |
+| `fast-observable`        | `@observable` decorator                   |
+| `fast-observable-notify` | `Observable.notify(...)`                  |
+| `fast-observable-track`  | `Observable.track(...)`                   |
+| `fast-dispatch`          | `$emit` to dispatch the custom event      |
+| `fast-when`              | `when`for conditional rendering           |
+
 ### Web Components Snippets
 
 | Snippet                   | Purpose                           |
@@ -75,8 +93,11 @@ Start typing `lit-*` and hit `enter`, the snippet spreads out or e.g. `lit-compo
 | `wc-observed-attrs`       | Define `observedAttributes`       |
 | `wc-adopted-cb`           | Define `adoptedCallback`          |
 | `wc-attribute-changed-cb` | Define `attributeChangedCallback` |
+| `wc-slot`                 | Define `<slot>`                   |
+| `wc-slot-named`           | Define `<slot name="name">`       |
 
-## Using NgRx or Angular material
+## Using NgRx or Angular material 🤔
 
-- Check out [NgRx Snippets](https://bit.ly/ngrx-vscode)
-- Check out [Angular Material Snippets](https://bit.ly/ng-material-vscode)
+- Check out:
+  - [NgRx Snippets](https://bit.ly/ngrx-vscode)
+  - [Angular Material Snippets](https://bit.ly/ng-material-vscode)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lit-snippets",
-  "displayName": "Lit and Web Components snippets",
-  "description": "LitElement, lit-html, and Webcomponent with HTML and JS snippets",
+  "displayName": "Web Components Snippets",
+  "description": "LitElement, lit-html, Stencil, FASTElement and WebComponent with HTML and JS snippets",
   "version": "2.0.0",
   "publisher": "hardikpthv",
   "license": "MIT",
@@ -21,6 +21,7 @@
   "keywords": [
     "lit-html",
     "LitElement",
+    "FASTElement",
     "stencil",
     "js",
     "Web component",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lit-snippets",
   "displayName": "Web Components Snippets",
   "description": "LitElement, lit-html, Stencil, FASTElement and WebComponent with HTML and JS snippets",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "publisher": "hardikpthv",
   "license": "MIT",
   "icon": "images/logo.png",

--- a/snippets/common.json
+++ b/snippets/common.json
@@ -72,7 +72,7 @@
     "body": ["constructor() {", "\tsuper()", "\t//${1:implementation}", "}"],
     "description": "Add constructor()"
   },
-  "litconnectedCallback": {
+  "litConnectedCallback": {
     "prefix": "lit-cb",
     "body": [
       "connectedCallback() {",
@@ -82,12 +82,12 @@
     ],
     "description": "connectedCallback() from LitElement"
   },
-  "litdisconnectedCallback": {
+  "litDisconnectedCallback": {
     "prefix": "lit-dcb",
     "body": ["disconnectedCallback() {", "\t${1://implementation}", "}"],
     "description": "disconnectedCallback() from LitElement"
   },
-  "litfirstUpdated": {
+  "litFirstUpdated": {
     "prefix": "lit-first-updated",
     "body": ["firstUpdated(changedProps) {", "\t${1://implementation}", "}"],
     "description": "firstUpdated() from LitElement"
@@ -229,6 +229,16 @@
     ],
     "description": "Define `attributeChangedCallback`"
   },
+  "wcSlot": {
+    "prefix": "wc-slot",
+    "body": ["<slot></slot>"],
+    "description": "Define <slot>"
+  },
+  "wcSlotNamed": {
+    "prefix": "wc-slot-named",
+    "body": ["<slot name=\"${1:slotName}\"></slot>"],
+    "description": "Define <slot> with name"
+  },
   "stencilComponent": {
     "prefix": "stencil-component",
     "body": [
@@ -332,5 +342,81 @@
     "prefix": "stencil-dcb",
     "body": ["disconnectedCallback() {", "\t${1://implementation}", "}"],
     "description": "disconnectedCallback() from Stencil"
+  },
+  "fastComponent": {
+    "prefix": "fast-component",
+    "body": [
+      "import { FASTElement, css, customElement, attr, html } from '@microsoft/fast-element';\n",
+      "const template = html<${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}>`",
+      "\t<h3>${x => x.greeting} World!</h3>",
+      "`;\n",
+      "const styles = css`",
+      "\t:host {",
+      "\t\t //styles",
+      "\t}",
+      "`;\n",
+      "@customElement({",
+      "\tname: '${TM_FILENAME_BASE/(.*)/${1:/downcase}/g}',",
+      "\ttemplate,",
+      "\tstyles",
+      "})",
+      "export class ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g} extends FASTElement {",
+      "\t@attr greeting: string = 'Hello';",
+      "\n\t${2://other logic}\n",
+      "}"
+    ],
+    "description": "Basic FASTElement Component"
+  },
+  "fastConnectedCallback": {
+    "prefix": "fast-cb",
+    "body": [
+      "connectedCallback() {",
+      "\tsuper.connectedCallback();",
+      "\t${1://implementation}",
+      "}"
+    ],
+    "description": "connectedCallback() from FASTElement"
+  },
+  "fastDisconnectedCallback": {
+    "prefix": "fast-dcb",
+    "body": [
+      "disconnectedCallback() {",
+      "\tsuper.disconnectedCallback();",
+      "\t${1://implementation}",
+      "}"
+    ],
+    "description": "disconnectedCallback() from FASTElement"
+  },
+  "fastObservable": {
+    "prefix": "fast-observable",
+    "body": [
+      "@observable ${1:observableName}: ${2:observableType} = ${3:value};"
+    ],
+    "description": "@observable decorator from FASTElement"
+  },
+  "fastObservableNotify": {
+    "prefix": "fast-observable-notify",
+    "body": ["Observable.notify(this, '${1:propName}');"],
+    "description": "Observable.notify from FASTElement"
+  },
+  "fastObservableTrack": {
+    "prefix": "fast-observable-track",
+    "body": ["Observable.track(this, '${1:propName}');"],
+    "description": "Observable.track from FASTElement"
+  },
+  "fastAttr": {
+    "prefix": "fast-attr",
+    "body": ["@attr ${1:attrName}: ${2:attrType} = ${3:value};"],
+    "description": "@attr decorator from FASTElement"
+  },
+  "fastDispatchEvent": {
+    "prefix": "fast-dispatch",
+    "body": ["this.\\$emit('${1:eventType}', ${2:value});"],
+    "description": "Dispatch event using this.$emit"
+  },
+  "fastWhen": {
+    "prefix": "fast-when",
+    "body": ["${when(${1:condition}, ${2:templateOrTemplateExpression})}"],
+    "description": "when directive"
   }
 }


### PR DESCRIPTION
- Update README for new snippets
- Add snippets for FASTElement:
  - `fast-component` - Basic FASTElement Component
  - `fast-cb` - `connectedCallback()` from FASTElement
  - `fast-dcb` - `disconnectedCallback()` from FASTElement
  - `fast-attr` - `@attr` decorator
  - `fast-observable` - `@observable` decorator
  - `fast-observable-notify` - `Observable.notify(...)`
  - `fast-observable-track -` `Observable.track(...)`
  - `fast-dispatch` - `$emit` to dispatch the custom event
  - `fast-when` - `when`for conditional rendering
- Add snippets for WebComponents/Generic:
  - `wc-slot` - Define `<slot>`
  - `wc-slot-named` - Define `<slot name="name">`